### PR TITLE
Add image generation command

### DIFF
--- a/md_batch_gpt/openai_client.py
+++ b/md_batch_gpt/openai_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Iterable
+import base64
 import time
 
 import openai
@@ -56,3 +57,15 @@ def send_prompt(
         {"role": "user", "content": content},
     ]
     return _chat_request(messages, model=model, temperature=1, max_tokens=max_tokens)
+
+
+def generate_image(prompt: str, model: str = "dall-e-3", size: str = "1024x1024") -> bytes:
+    """Return image bytes generated from *prompt* using the OpenAI image API."""
+    resp = _client.images.generate(
+        prompt=prompt,
+        model=model,
+        size=size,
+        response_format="b64_json",
+    )
+    b64_data = resp.data[0]["b64_json"]
+    return base64.b64decode(b64_data)

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,34 @@
+import importlib
+import base64
+
+
+def import_oc():
+    if "md_batch_gpt.openai_client" in importlib.sys.modules:
+        del importlib.sys.modules["md_batch_gpt.openai_client"]
+    return importlib.import_module("md_batch_gpt.openai_client")
+
+
+def test_generate_image(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    oc = import_oc()
+
+    b64 = base64.b64encode(b"imgdata").decode()
+
+    class DummyImages:
+        def __init__(self):
+            self.kwargs = None
+
+        def generate(self, **kwargs):
+            self.kwargs = kwargs
+            return type("Resp", (), {"data": [{"b64_json": b64}]})()
+
+    dummy_client = type("Client", (), {"images": DummyImages()})()
+
+    monkeypatch.setattr(oc, "_client", dummy_client)
+
+    result = oc.generate_image("a prompt", model="m")
+
+    assert result == b"imgdata"
+    assert dummy_client.images.kwargs["prompt"] == "a prompt"
+    assert dummy_client.images.kwargs["model"] == "m"
+    assert dummy_client.images.kwargs["response_format"] == "b64_json"


### PR DESCRIPTION
## Summary
- add helper to generate images using OpenAI
- extend CLI with `generate-image` command
- test new helper and CLI command
- adjust existing CLI tests for subcommand usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6878876e454083269049c8d2f67b01f2