### PR TITLE
Add bulk image generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Run the batch processor against the `docs` folder using the provided prompts:
 poetry run mdgpt run docs --prompts prompts/first.txt prompts/second.txt
 ```
 
+Generate images from JSON description files:
+```bash
+poetry run mdgpt generate-images images1.json images2.json --model dall-e-3 --size 1024x1024
+```
+
 ## .env Setup
 
 The application requires an OpenAI API key. Create a `.env` file in the project

--- a/md_batch_gpt/openai_client.py
+++ b/md_batch_gpt/openai_client.py
@@ -59,7 +59,9 @@ def send_prompt(
     return _chat_request(messages, model=model, temperature=1, max_tokens=max_tokens)
 
 
-def generate_image(prompt: str, model: str = "dall-e-3", size: str = "1024x1024") -> bytes:
+def generate_image(
+    prompt: str, model: str = "dall-e-3", size: str = "1024x1024"
+) -> bytes:
     """Return image bytes generated from *prompt* using the OpenAI image API."""
     resp = _client.images.generate(
         prompt=prompt,


### PR DESCRIPTION
## Summary
- add `generate-images` Typer command for bulk image generation
- validate JSON entries before generating images
- extend CLI tests and create new test for generate-images
- document the new command in the README
- format with Black

## Testing
- `ruff check md_batch_gpt tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68788b00c67c83268b3582aa9d412d00