### PR TITLE
Update README for art focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # md-batch-gpt
 
-Poetry-managed Python 3.11 project.
+Utilities for generating visual art at scale. This project grew out of an
+earlier automation approach known as the **two prong** workflow and is focused
+on producing image assets from structured prompts. Poetry-managed Python 3.11
+project.
 
 ## Installation
 
@@ -18,9 +21,13 @@ Run the batch processor against the `docs` folder using the provided prompts:
 poetry run mdgpt run docs --prompts prompts/first.txt prompts/second.txt
 ```
 
-Generate images from JSON description files:
+Generate images from JSON description files. Each entry must include
+`expected_filename` and `summary` keys. Any additional fields are ignored.
+The prompt text comes from `summary`, and the resulting image is saved to
+`expected_filename`.
+
 ```bash
-poetry run mdgpt generate-images images1.json images2.json --model dall-e-3 --size 1024x1024
+poetry run mdgpt generate-images images1.json images2.json --model gpt-image-1 --size 1024x1024
 ```
 
 ## .env Setup


### PR DESCRIPTION
## Summary
- clarify that the project generates art assets and grew from the two prong workflow
- document required JSON fields for image generation
- show example using `gpt-image-1`

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68788d4d202483268de011bac69fde03