### PR TITLE
Add docs image generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ The prompt text comes from `summary`, and the resulting image is saved to
 
 ```bash
 poetry run mdgpt generate-images images1.json images2.json --model gpt-image-1 --size 1024x1024
+```
+
+Images can also be generated directly from Markdown files. Each document must
+begin with YAML front-matter providing `expected_filename` and `summary`:
+
+```markdown
+---
+expected_filename: example.png
+summary: An example scene
+---
+```
+
+```bash
+poetry run mdgpt generate-images-from-docs docs --model gpt-image-1 --size 1024x1024
+```
 
 
 ## .env Setup

--- a/md_batch_gpt/markdown_parser.py
+++ b/md_batch_gpt/markdown_parser.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+import yaml
+
+from .file_io import iter_markdown_files
+
+
+def parse_markdown_image_entries(folder: Path) -> List[Dict[str, str]]:
+    """Return a list of image generation entries from Markdown files in *folder*.
+
+    Each Markdown file must start with YAML front-matter containing
+    ``expected_filename`` and ``summary`` keys. Any additional fields are
+    ignored. The function uses :func:`iter_markdown_files` to locate ``*.md``
+    files under *folder*.
+    """
+    entries: List[Dict[str, str]] = []
+    for md_path in iter_markdown_files(folder):
+        text = md_path.read_text(encoding="utf-8", errors="replace")
+        if not text.startswith("---"):
+            raise ValueError(f"{md_path} missing YAML front matter")
+        parts = text.split("---", 2)
+        if len(parts) < 3:
+            raise ValueError(f"{md_path} missing closing YAML delimiter")
+        fm_text = parts[1]
+        data = yaml.safe_load(fm_text) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"{md_path} front matter is not a mapping")
+        filename = data.get("expected_filename")
+        summary = data.get("summary")
+        if not filename or not summary:
+            raise ValueError(
+                f"{md_path} front matter missing expected_filename or summary"
+            )
+        entries.append({"expected_filename": filename, "summary": summary})
+    return entries


### PR DESCRIPTION
## Summary
- parse YAML front matter in Markdown files with `parse_markdown_image_entries`
- expose `generate-images-from-docs` command in CLI
- implement tests for generating images from docs
- document Markdown-based workflow in README

## Testing
- `ruff check md_batch_gpt tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6878921087e08326af72c2279f8184d0