### PR TITLE
Add JSON spec support for image docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ The prompt text comes from `summary`, and the resulting image is saved to
 poetry run mdgpt generate-images images1.json images2.json --model gpt-image-1 --size 1024x1024
 ```
 
-Images can also be generated directly from Markdown files. Each document can
-either begin with YAML front-matter providing `expected_filename` and
-`summary`, or contain a JSON code block with one or more such entries:
+Images can also be generated directly from Markdown or JSON files. Markdown
+documents may begin with YAML front-matter providing `expected_filename` and
+`summary`, or contain a JSON code block with one or more such entries. Any
+`*.json` files found in the same folder are treated as specification objects and
+used to build the prompt.
 
 ```markdown
 ---


### PR DESCRIPTION
## Summary
- add ability for `generate-images-from-docs` to parse `*.json` files
- build prompts from JSON fields when `alt_text` is present
- document the new behavior
- test that JSON spec files are supported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68789940434883268e3d1bff59dae257