### PR TITLE
Handle JSON spec lists

### DIFF
--- a/md_batch_gpt/markdown_parser.py
+++ b/md_batch_gpt/markdown_parser.py
@@ -17,7 +17,7 @@ def parse_markdown_image_entries(folder: Path) -> List[Dict[str, str]]:
     :func:`iter_markdown_files` to locate ``*.md`` files under *folder*.
     """
     entries: List[Dict[str, str]] = []
-    for md_path in iter_markdown_files(folder):
+    for md_path in sorted(iter_markdown_files(folder)):
         text = md_path.read_text(encoding="utf-8", errors="replace")
         stripped = text.lstrip()
         if stripped.startswith("---"):


### PR DESCRIPTION
## Summary
- allow generate-images-from-docs to load JSON files containing lists
- preserve deterministic ordering when parsing Markdown image entries
- test JSON list handling for generate-images-from-docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68789c40198883268b1f4afaa28cc149