### PR TITLE
Fix OpenAI image API call for v1 client

### DIFF
--- a/md_batch_gpt/openai_client.py
+++ b/md_batch_gpt/openai_client.py
@@ -63,16 +63,15 @@ def generate_image(
     prompt: str, model: str = "dall-e-3", size: str = "1024x1024"
 ) -> bytes:
     """Return image bytes generated from *prompt* using the OpenAI image API."""
-    # newer OpenAI client doesn't accept ``response_format``; default returns URLs
-    resp = openai.Image.create(
+    resp = _client.images.generate(
         prompt=prompt,
         model=model,
         size=size,
     )
-    node = resp["data"][0]
-    if "url" in node:
+    node = resp.data[0]
+    if getattr(node, "url", None):
         import requests
-        return requests.get(node["url"]).content
-    if "b64_json" in node:
-        return base64.b64decode(node["b64_json"])
+        return requests.get(node.url).content
+    if getattr(node, "b64_json", None):
+        return base64.b64decode(node.b64_json)
     raise RuntimeError("No image data in API response")

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -16,11 +16,15 @@ def test_generate_image(monkeypatch):
 
     captured_kwargs = {}
 
-    def dummy_create(**kwargs):
-        captured_kwargs.update(kwargs)
-        return {"data": [{"b64_json": b64}]}
+    class DummyResp:
+        def __init__(self, data):
+            self.data = data
 
-    monkeypatch.setattr(oc.openai.Image, "create", dummy_create)
+    def dummy_generate(**kwargs):
+        captured_kwargs.update(kwargs)
+        return DummyResp([type("Node", (), {"b64_json": b64})])
+
+    monkeypatch.setattr(oc._client.images, "generate", dummy_generate)
 
     result = oc.generate_image("a prompt", model="m")
 


### PR DESCRIPTION
## Summary
- update image generation logic to use `OpenAI.images.generate`
- adjust tests for new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68789ece24c883269a8f422fb18b782a