### PR TITLE
Add docs alias for image commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ summary: An example scene
 poetry run mdgpt generate-images-from-docs docs --model gpt-image-1 --size 1024x1024
 ```
 
+The same functionality is available via the shorter `docs` alias:
+
+```bash
+poetry run mdgpt docs docs --model gpt-image-1 --size 1024x1024
+```
+
 
 ## .env Setup
 

--- a/md_batch_gpt/cli.py
+++ b/md_batch_gpt/cli.py
@@ -207,5 +207,25 @@ def generate_images_from_docs_cmd(
             typer.echo(f"Wrote {filename}")
 
 
+@app.command("docs")
+def docs_cmd(
+    docs_folder: Path = typer.Argument(
+        ..., exists=True, file_okay=False, dir_okay=True
+    ),
+    model: str = typer.Option(
+        "dall-e-3", "--model", help="OpenAI model for image generation"
+    ),
+    size: str = typer.Option("1024x1024", "--size", help="Image size, e.g. 1024x1024"),
+    verbose: bool = typer.Option(False, "--verbose", "-v"),
+) -> None:
+    """Alias for :func:`generate_images_from_docs_cmd`."""
+    generate_images_from_docs_cmd(
+        docs_folder,
+        model=model,
+        size=size,
+        verbose=verbose,
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -493,3 +493,45 @@ def test_generate_images_from_docs_json_list(monkeypatch, tmp_path: Path):
     assert prompts == ["A", "B"]
     assert all(c[1:] == ("m", "256x256") for c in calls)
 
+
+def test_docs_alias(monkeypatch, tmp_path: Path):
+    """The `docs` command should behave like `generate-images-from-docs`."""
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    cli = import_cli()
+
+    called = {}
+
+    def fake_cmd(docs_folder: Path, model: str = "dall-e-3", size: str = "1024x1024", verbose: bool = False) -> None:
+        called["folder"] = docs_folder
+        called["model"] = model
+        called["size"] = size
+        called["verbose"] = verbose
+
+    monkeypatch.setattr(cli, "generate_images_from_docs_cmd", fake_cmd)
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "docs",
+            str(docs),
+            "--model",
+            "m",
+            "--size",
+            "256x256",
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert called == {
+        "folder": docs,
+        "model": "m",
+        "size": "256x256",
+        "verbose": True,
+    }
+


### PR DESCRIPTION
## Summary
- add `docs` command aliasing `generate-images-from-docs`
- document the new command in README
- test that the alias invokes the underlying command

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a216f3edc83269536f183f286b6dc